### PR TITLE
Allow user to follow (and block) hashtags

### DIFF
--- a/packages/backend/migration/1712201438090-hashtag-following-and-blocking.js
+++ b/packages/backend/migration/1712201438090-hashtag-following-and-blocking.js
@@ -1,0 +1,15 @@
+export class HashtagFollowingAndBlocking1712201438090 {
+    name = 'HashtagFollowingAndBlocking1712201438090'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user" ADD "followedHashtags" character varying(128) array NOT NULL DEFAULT '{}'`);
+        await queryRunner.query(`COMMENT ON COLUMN "user"."followedHashtags" IS 'Hashtags that will appear in the User''s timeline.'`);
+        await queryRunner.query(`ALTER TABLE "user" ADD "blockedHashtags" character varying(128) array NOT NULL DEFAULT '{}'`);
+        await queryRunner.query(`COMMENT ON COLUMN "user"."blockedHashtags" IS 'Hashtags that will be blocked from the User''s timeline, taking precedence over follow.'`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "blockedHashtags"`);
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "followedHashtags"`);
+    }
+}

--- a/packages/backend/src/models/entities/user.ts
+++ b/packages/backend/src/models/entities/user.ts
@@ -130,6 +130,24 @@ export class User {
 	})
 	public tags: string[];
 
+	@Index()
+	@Column("varchar", {
+		length: 128,
+		array: true,
+		default: "{}",
+		comment: "Hashtags that will appear in the User's timeline."
+	})
+	public followedHashtags: string[];
+
+	@Index()
+	@Column("varchar", {
+		length: 128,
+		array: true,
+		default: "{}",
+		comment: "Hashtags that will be blocked from the User's timeline, taking precedence over follow."
+	})
+	public blockedHashtags: string[];
+
 	@Column("boolean", {
 		default: false,
 		comment: "Whether the User is suspended.",

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -94,6 +94,9 @@ export default define(meta, paramDef, async (ps, user) => {
 
 	generateRepliesQuery(query, ps.withReplies, user);
 	if (user) {
+		query.innerJoinAndSelect("user", "me", "me.id = :meId", { meId: user.id });
+		query.andWhere("NOT (note.tags && me.blockedHashtags)");
+
 		generateMutedUserQuery(query, user);
 		generateMutedNoteQuery(query, user);
 		generateBlockedUserQuery(query, user);

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -87,14 +87,18 @@ export default define(meta, paramDef, async (ps, user) => {
 		ps.sinceDate,
 		ps.untilDate,
 	)
-		.andWhere(
-			new Brackets((qb) => {
+
+		.andWhere("NOT (note.tags && me.blockedHashtags)")
+		.andWhere(new Brackets((qb) => {
 				qb.where(
 					`((note.userId IN (${followingQuery.getQuery()})) OR (note.userId = :meId))`,
 					{ meId: user.id },
-				).orWhere("(note.visibility = 'public') AND (note.userHost IS NULL)");
+				)
+				qb.orWhere("(note.tags && me.followedHashtags)");
+				qb.orWhere("(note.visibility = 'public') AND (note.userHost IS NULL)");
 			}),
 		)
+		.innerJoinAndSelect("user", "me", "me.id = :meId", { meId: user.id })
 		.innerJoinAndSelect("note.user", "user")
 		.leftJoinAndSelect("user.avatar", "avatar")
 		.leftJoinAndSelect("user.banner", "banner")

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -1,4 +1,4 @@
-import { Brackets } from "typeorm";
+import { Brackets, SelectQueryBuilder } from "typeorm";
 import { fetchMeta } from "@/misc/fetch-meta.js";
 import { Notes, Users } from "@/models/index.js";
 import { activeUsersChart } from "@/services/chart/index.js";
@@ -106,6 +106,11 @@ export default define(meta, paramDef, async (ps, user) => {
 		.leftJoinAndSelect("renote.user", "renoteUser")
 		.leftJoinAndSelect("renoteUser.avatar", "renoteUserAvatar")
 		.leftJoinAndSelect("renoteUser.banner", "renoteUserBanner");
+
+	if (user) {
+		query.innerJoinAndSelect("user", "me", "me.id = :meId", { meId: user.id });
+		query.andWhere("NOT (note.tags && me.blockedHashtags)");
+	}
 
 	generateChannelQuery(query, user);
 	generateRepliesQuery(query, ps.withReplies, user);

--- a/packages/backend/src/server/api/endpoints/notes/mentions.ts
+++ b/packages/backend/src/server/api/endpoints/notes/mentions.ts
@@ -55,7 +55,9 @@ export default define(meta, paramDef, async (ps, user) => {
 				);
 			}),
 		)
+		.andWhere("NOT (note.tags && me.blockedHashtags)")
 		.innerJoinAndSelect("note.user", "user")
+		.innerJoinAndSelect("me", "user", "user.id = :meId", { meId: user.id })
 		.leftJoinAndSelect("user.avatar", "avatar")
 		.leftJoinAndSelect("user.banner", "banner")
 		.leftJoinAndSelect("note.reply", "reply")

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -84,14 +84,18 @@ export default define(meta, paramDef, async (ps, user) => {
 		ps.sinceDate,
 		ps.untilDate,
 	)
+		.andWhere("NOT (note.tags && me.blockedHashtags)")
 		.andWhere(
 			new Brackets((qb) => {
 				qb.where("note.userId = :meId", { meId: user.id });
-				if (hasFollowing)
+				qb.orWhere("note.tags && me.followedHashtags");
+				if (hasFollowing) {
 					qb.orWhere(`note.userId IN (${followingQuery.getQuery()})`);
-			}),
+				}
+			})
 		)
 		.innerJoinAndSelect("note.user", "user")
+		.innerJoinAndSelect("user", "me", "me.id = :meId", { meId: user.id })
 		.leftJoinAndSelect("user.avatar", "avatar")
 		.leftJoinAndSelect("user.banner", "banner")
 		.leftJoinAndSelect("note.reply", "reply")


### PR DESCRIPTION
# Database stuff (done)

1. Adds `followedHashtags` and `blockedHashtags` to User schema as arrays of `varchar(128)`
2. Edits all timeline queries to automatically conceal posts tagged with any blocked hashtags
3. Edits personal timeline queries (home, social) to also match posts tagged with any followed hashtags

# API stuff (nothing done yet)

1. Implement `/api/v1/tags/:id/follow`
2. Implement `/api/v1/tags/:id/unfollow`
3. Implement `/api/v1/tags/:id/block`
4. Implement `/api/v1/tags/:id/unblock`

The block and unblock endpoints will be **non-standard** extensions; the Mastodon API has no concept of followed/blocked hashtags, it only uses text filtering for strings.

# Frontend stuff - following (nothing done yet)

1. Create `MkFollowHashtagButton` component
2. Add button to top of page when you search on a tag
3. Add list of currently followed hashtags to profile

# Frontend stuff - blocking (nothing done yet)

1. Create `MkBlockHashtagButton` component(?)
2. Add Blocked Hashtags to Mutes and Blocks settings pane
3. Add UI to Mutes & Blocks to undo a block