### PR TITLE
sanitize message at the repository level

### DIFF
--- a/packages/backend/src/models/repositories/messaging-message.ts
+++ b/packages/backend/src/models/repositories/messaging-message.ts
@@ -3,6 +3,7 @@ import { MessagingMessage } from "@/models/entities/messaging-message.js";
 import { Users, DriveFiles, UserGroups } from "../index.js";
 import type { Packed } from "@/misc/schema.js";
 import type { User } from "@/models/entities/user.js";
+import sanitize from "sanitize-html";
 
 export const MessagingMessageRepository = db
 	.getRepository(MessagingMessage)
@@ -26,7 +27,7 @@ export const MessagingMessageRepository = db
 			return {
 				id: message.id,
 				createdAt: message.createdAt.toISOString(),
-				text: message.text,
+				text: message.text ? sanitize(message.text) : null,
 				userId: message.userId,
 				user: await Users.pack(message.user || message.userId, me),
 				recipientId: message.recipientId,

--- a/packages/backend/src/services/messages/create.ts
+++ b/packages/backend/src/services/messages/create.ts
@@ -22,6 +22,7 @@ import renderNote from "@/remote/activitypub/renderer/note.js";
 import renderCreate from "@/remote/activitypub/renderer/create.js";
 import { renderActivity } from "@/remote/activitypub/renderer/index.js";
 import { deliver } from "@/queue/index.js";
+import sanitize from "sanitize-html";
 
 export async function createMessage(
 	user: { id: User["id"]; host: User["host"] },
@@ -37,7 +38,7 @@ export async function createMessage(
 		fileId: file ? file.id : null,
 		recipientId: recipientUser ? recipientUser.id : null,
 		groupId: recipientGroup ? recipientGroup.id : null,
-		text: text ? text.trim() : null,
+		text: text ? sanitize(text.trim()) : null,
 		userId: user.id,
 		isRead: false,
 		reads: [] as any[],

--- a/packages/client/src/components/MkChatPreview.vue
+++ b/packages/client/src/components/MkChatPreview.vue
@@ -51,10 +51,7 @@
 					<span v-if="isMe(message)" class="me"
 						>{{ i18n.ts.you }}:
 					</span>
-					<Mfm
-						v-if="message.text != null && message.text.length > 0"
-						:text="message.text"
-					/>
+					<span v-if="message.text != null && message.text.length > 0" v-html="message.text"></span>
 					<span v-else> 📎</span>
 				</p>
 			</div>

--- a/packages/client/src/pages/messaging/messaging-room.message.vue
+++ b/packages/client/src/pages/messaging/messaging-room.message.vue
@@ -20,13 +20,7 @@
 					></i>
 				</button>
 				<div v-if="!message.isDeleted" class="content">
-					<Mfm
-						v-if="message.text"
-						ref="text"
-						class="text"
-						:text="message.text"
-						:i="$i"
-					/>
+					<div class="text" v-html="message.text"></div>
 				</div>
 				<div v-else class="content">
 					<p class="is-deleted">{{ i18n.ts.deleted }}</p>


### PR DESCRIPTION
1. Make message display (chats list and chat history) render HTML.
2. The message repository *must* defang any HTML that comes in, so use `sanitize-html` on it.
3. When the user posts to the `messaging/create` endpoint, defang whatever HTML they may try to submit.