### PR TITLE
Note: only attach slug url to local notes

### DIFF
--- a/packages/backend/src/services/note/create.ts
+++ b/packages/backend/src/services/note/create.ts
@@ -380,7 +380,10 @@ export default async (
 
 		data.slug = await getNoteSlug(data as Note);
 		logger.info("created slug: " + data.slug);
-		if (user.username && data.slug && !data.url) {
+		// Only attach these slug URLs to local notes since they
+		// always reference the local server, not the originating
+		// server
+		if (user.username && data.slug && !data.url && !Users.isRemoteUser(user)) {
 			const host = user.host ? "@" + user.host : "";
 			data.url = `${config.url}/@${user.username}${host}/${data.slug}`;
 		}


### PR DESCRIPTION
Since these URLs always point to notes on the local server, attaching them to remote notes breaks things like the "open original page" link and causes them to just direct back to the local server instead of the remote note.

This doesn't affect Mastodon notes since those federate in with both the `url` and `uri` fields. Since *key posts don't have `url`, this has been setting them to a Goblin-local URL instead of something that actually references the remote note.

When this is shipped, it may also be worth adding a migration which nulls out the `url` field for any affected remote notes (eg notes that aren't local, but whose `url` begins with `config.url`).

Fixes #90.